### PR TITLE
Updated to latest ShopChest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,11 @@ local.properties
 .idea
 dependency-reduced-pom.xml
 desktop.ini
+
+ArmShopBridge/target
+interfaces/target
+quickshop4adapter/target
+quickshopadapter/target
+shopchestadapter/target
+shopkeepersadapter/target
+ultimateshopsadapter/target

--- a/shopchestadapter/pom.xml
+++ b/shopchestadapter/pom.xml
@@ -14,8 +14,8 @@
 
     <repositories>
         <repository>
-            <id>shopchest-repo</id>
-            <url>https://epicericee.github.io/ShopChest/maven/</url>
+            <id>codemc-repo</id>
+            <url>https://repo.codemc.io/repository/maven-public/</url>
         </repository>
     </repositories>
 

--- a/shopchestadapter/pom.xml
+++ b/shopchestadapter/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>de.epiceric</groupId>
             <artifactId>ShopChest</artifactId>
-            <version>1.11.1</version>
+            <version>1.13-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/shopchestadapter/src/main/java/net/alex9849/armshopbridge/adapters/ShopChestAdapter.java
+++ b/shopchestadapter/src/main/java/net/alex9849/armshopbridge/adapters/ShopChestAdapter.java
@@ -7,11 +7,13 @@ import net.alex9849.arm.regions.Region;
 import net.alex9849.armshopbridge.interfaces.IShopPluginAdapter;
 import org.bukkit.Location;
 
+import java.util.Collection;
+
 public class ShopChestAdapter implements IShopPluginAdapter {
     @Override
     public void deleteShops(Region region) {
         ShopUtils shopUtils = ShopChest.getInstance().getShopUtils();
-        Shop[] shops = shopUtils.getShops().clone();
+        Collection<Shop> shops = shopUtils.getShops();
 
         for(Shop shop : shops) {
             Location loc = shop.getLocation();


### PR DESCRIPTION
Updates to the latest version of ShopChest (1.13-SNAPSHOT) which works with 1.13-1.15 being as a spigot version hasn't been released in ages.

Also adds the target directories to gitignore. 